### PR TITLE
Automate OWNERS_ALIASES propagation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-# Default owners are Serving/Eventing WG leads, Productivity, and TOC
-* @knative-sandbox/technical-oversight-committee
-* @knative-sandbox/knative-release-leads
-* @knative-sandbox/serving-writers
-* @knative-sandbox/eventing-writers
-# Last match takes precedence for reviews
-* @knative-sandbox/productivity-wg-leads
+* @knative-sandbox/productivity-wg-leads @knative-sandbox/serving-writers @knative-sandbox/eventing-writers @knative-sandbox/technical-oversight-committee @knative-sandbox/knative-release-lead

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owners are Serving/Eventing WG leads, Productivity, and TOC
+* @knative-sandbox/technical-oversight-committee
+* @knative-sandbox/knative-release-leads
+* @knative-sandbox/serving-writers
+* @knative-sandbox/eventing-writers
+# Last match takes precedence for reviews
+* @knative-sandbox/productivity-wg-leads

--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check Repo
-      run: GITHUB_TOKEN=${{ PERSONAL_ACCESS_TOKEN }} ./hack/auto-fork.sh ${{ matrix.org }}
+      run: GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN }} ./hack/auto-fork.sh ${{ matrix.org }}
 
     - name: Post failure notice to Slack
       uses: rtCamp/action-slack-notify@v2.1.0

--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -40,7 +40,7 @@ jobs:
         go-version: 1.15.x
 
     - name: Install Dependencies
-      run: go get knative.dev/test-infra/buoy@master
+      run: GO111MODULE=on go get knative.dev/test-infra/buoy@master
 
     - name: Install gh
       run: |

--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -1,0 +1,70 @@
+# Copyright 2021 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto-Fork
+
+on:
+  schedule:
+  - cron: '0 10 * * 1-5' # 3am Pacific on weekdays
+
+  workflow_dispatch:
+
+jobs:
+
+  forky:
+    name: Auto-Fork
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        org:
+        - knative-sandbox
+        - knative
+
+    steps:
+
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+
+    - name: Install Dependencies
+      run: go get knative.dev/test-infra/buoy@master
+
+    - name: Install gh
+      run: |
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+        sudo apt-add-repository https://cli.github.com/packages
+        sudo apt update
+        sudo apt install gh
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+
+    - name: Check Repo
+      run: GITHUB_TOKEN=${{ PERSONAL_ACCESS_TOKEN }} ./hack/auto-fork.sh ${{ matrix.org }}
+
+    - name: Post failure notice to Slack
+      uses: rtCamp/action-slack-notify@v2.1.0
+      if: ${{ failure() }}
+      env:
+        SLACK_ICON: http://github.com/knative-automation.png?size=48
+        SLACK_USERNAME: knative-automation
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: 'productivity'
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'true'
+        SLACK_TITLE: Auto-fork ${{ matrix.org }} failed.
+        SLACK_MESSAGE: |
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -38,7 +38,7 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.20'
+      RELEASE: 'v0.21'
       #########################################
       DEFAULT_BRANCH: 'master'
     outputs:

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -151,18 +151,20 @@ jobs:
     - name: Install Dependencies
       run: |
         cd $(mktemp -d)
-        
+
         echo '::group:: install ko'
         curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
         chmod +x ./ko
         sudo mv ko /usr/local/bin
         echo '::endgroup::'
-        
+
         go get github.com/google/licenseclassifier
         go get github.com/google/go-licenses
+        go get github.com/dprotaso/modlog
         go get knative.dev/test-infra/buoy
 
     - name: Update Deps and Codegen
+      id: updatedeps
       shell: bash
       run: |
         # Determine the name of the go module.
@@ -182,8 +184,9 @@ jobs:
           release_flag="--release ${{ needs.meta.outputs.release }}"
         fi
 
+        echo "::set-output name=update-dep-cmd::./hack/update-deps.sh --upgrade ${release_flag}"
         ./hack/update-deps.sh --upgrade ${release_flag}
-        
+
         # We may pull in code-generator updates, or not have generated code.
         [[ ! -f hack/update-codegen.sh ]] || ./hack/update-codegen.sh
 
@@ -204,6 +207,15 @@ jobs:
           break
         done
 
+        # capture logs for the module changes
+        errout=$(mktemp)
+        deplog=$(modlog . HEAD dirty 2>$errout)
+        cat $errout
+        deplog="${deplog//$'\n'/'%0A'}"
+        deplog="${deplog//$'\r'/'%0D'}"
+        echo "::set-output name=deplog::$deplog"
+
+
     - name: Create Pull Request
       id: cpr
       if: env.create_pr == 'true'
@@ -221,17 +233,28 @@ jobs:
         delete-branch: true
 
         # Description of the change and PR body.
-        commit-message: 'upgrade to latest dependencies'
+        commit-message: |
+          upgrade to latest dependencies
+
+          ${{ steps.updatedeps.outputs.deplog }}
+
         title: '[${{ needs.meta.outputs.branch }}] Upgrade to latest dependencies'
         body: |
-          Produced via:
-          ```shell
-          ./hack/update-deps.sh --upgrade
-          ./hack/update-codegen.sh
-          ```
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
+
           /cc ${{ matrix.assignees }}
           /assign ${{ matrix.assignees }}
+
+          Produced via:
+          ```shell
+          ${{ steps.updatedeps.outputs.update-dep-cmd}}
+          ./hack/update-codegen.sh
+          ```
+
+          Details:
+          ```
+          ${{ steps.updatedeps.outputs.deplog }}
+          ```
 
     - name: Post failure notice to Slack
       uses: rtCamp/action-slack-notify@v2.1.0

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -41,6 +41,8 @@ jobs:
     outputs:
       actions-include: ${{ steps.load-matrix.outputs.actions-include }}
       actions-names: ${{ steps.load-matrix.outputs.actions-names }}
+      community-include: ${{ steps.load-matrix.outputs.community-include }}
+      community-names: ${{ steps.load-matrix.outputs.community-names }}
       deps-include: ${{ steps.load-matrix.outputs.deps-include }}
       deps-names: ${{ steps.load-matrix.outputs.deps-names }}
       gotool-include: ${{ steps.load-matrix.outputs.gotool-include }}
@@ -76,7 +78,7 @@ jobs:
           filtered_repos "$1" | jq -c "map(.name)"
         }
 
-        for x in actions deps gotool misspell prettier ; do
+        for x in actions community deps gotool misspell prettier ; do
           echo "::group::Matrix names for $x"
           filtered_names $x-exclude.yaml | jq .
           echo "::endgroup::"
@@ -522,6 +524,97 @@ jobs:
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
         SLACK_TITLE: Copy actions for ${{ matrix.name }} failed.
+        SLACK_MESSAGE: |
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
+
+  update-community:
+    name: Update Knative Community files (OWNERS_ALIASES)
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      max-parallel: 5
+      matrix:
+        name: ${{fromJson(needs.meta.outputs.community-names)}}
+        include: ${{fromJson(needs.meta.outputs.community-include)}}
+
+    env:
+      GO111MODULE: on
+
+    steps:
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: main
+        repository: ${{ matrix.name }}
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: meta
+        repository: "knative/community"
+
+    - name: Copy OWNERS_ALIASES
+      shell: bash
+      run: |
+        FILE="OWNERS_ALIASES"
+        if [ "${{ matrix.meta-organization }}" != "knative" ] ; then
+          FILE="${{ matrix.meta-organization }}-OWNERS_ALIASES"
+        fi
+        if [ -f "${GITHUB_WORKSPACE}/meta/${FILE}" ] ; then
+          cp "${GITHUB_WORKSPACE}/meta/${FILE}" "${GITHUB_WORKSPACE}/main/OWNERS_ALIASES"
+        fi
+        # TODO: copy other files over, like CODE-OF-CONDUCT.md
+
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        # Who to look like
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        committer: "Knative Automation <automation@knative.team>"
+        author: "Knative Automation <automation@knative.team>"
+
+        # Where to stage the change.
+        push-to-fork: ${{ matrix.fork }}
+        branch: auto-updates/common-aliases
+        signoff: true
+        delete-branch: true
+        path: matrix.name
+
+        commit-message: 'Update knative/community files'
+        title: '[Automated] Update knative/community files'
+        body: |
+          Produced via:
+          ```shell
+          # meta: knative/community
+          # main: ${{matrix.name}}
+          FILE="OWNERS_ALIASES"
+          if [ "${{ matrix.meta-organization }}" != "knative" ] ; then
+            FILE="${{ matrix.meta-organization }}-OWNERS_ALIASES"
+          fi
+          if [ -f "${GITHUB_WORKSPACE}/meta/${FILE}" ] ; then
+            cp "${GITHUB_WORKSPACE}/meta/${FILE}" "${GITHUB_WORKSPACE}/main/OWNERS_ALIASES"
+          fi
+          ```
+          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
+          /cc ${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
+
+    - name: Post failure notice to Slack
+      uses: rtCamp/action-slack-notify@v2.1.0
+      if: ${{ failure() }}
+      env:
+        SLACK_ICON: http://github.com/knative-automation.png?size=48
+        SLACK_USERNAME: knative-automation
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+        SLACK_CHANNEL: ${{ matrix.channel }}
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'true'
+        SLACK_TITLE: Copy community for ${{ matrix.name }} failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -36,7 +36,7 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.21'
+      RELEASE: 'v0.22'
       #########################################
     outputs:
       actions-include: ${{ steps.load-matrix.outputs.actions-include }}

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -395,7 +395,7 @@ jobs:
       run: |
         export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
         if (( ${#FILES[@]} > 0 )); then
-          misspell -w "${FILES[@]}"
+          misspell -i importas -w "${FILES[@]}"
         else
           echo No files found.
         fi

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -208,9 +208,7 @@ jobs:
         done
 
         # capture logs for the module changes
-        errout=$(mktemp)
-        deplog=$(modlog . HEAD dirty 2>$errout)
-        cat $errout
+        deplog=$(modlog . HEAD dirty || true)
         deplog="${deplog//$'\n'/'%0A'}"
         deplog="${deplog//$'\r'/'%0D'}"
         echo "::set-output name=deplog::$deplog"

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -21,9 +21,9 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch Name? (master)'
+        description: 'Branch Name? (empty for default branch of the respective repository)'
         required: true
-        default: 'master'
+        default: ''
 
       release:
         description: 'Release? (vX.Y) defaults to current release'
@@ -40,7 +40,6 @@ jobs:
       #   Update this section each release.   #
       RELEASE: 'v0.21'
       #########################################
-      DEFAULT_BRANCH: 'master'
     outputs:
       actions-include: ${{ steps.load-matrix.outputs.actions-include }}
       actions-names: ${{ steps.load-matrix.outputs.actions-names }}
@@ -100,11 +99,7 @@ jobs:
         done
 
         # Create a properly default property for downstream.
-        if [[ "${{ github.event.inputs.branch }}" != "" ]]; then
-          echo "::set-output name=branch::${{ github.event.inputs.branch }}"
-        else
-          echo "::set-output name=branch::${DEFAULT_BRANCH}"
-        fi
+        echo "::set-output name=branch::${{ github.event.inputs.branch }}"
 
         # If manual trigger sent release.
         if [[ "${{ github.event.inputs.release }}" != "" ]]; then
@@ -147,6 +142,12 @@ jobs:
       with:
         repository: ${{ matrix.name }}
         ref: ${{ needs.meta.outputs.branch }}
+
+    # This is required because the branch setting might be empty (to infer a default), so
+    # after checkout we fetch what the checkout action decided to check out.
+    - name: Infer branch from checkout
+      run: |
+        echo "::set-output name=branch::$(git branch --show-current)"
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -22,8 +22,6 @@ on:
     inputs:
       branch:
         description: 'Branch Name? (empty for default branch of the respective repository)'
-        required: true
-        default: ''
 
       release:
         description: 'Release? (vX.Y) defaults to current release'
@@ -51,7 +49,6 @@ jobs:
       misspell-names: ${{ steps.load-matrix.outputs.misspell-names }}
       prettier-include: ${{ steps.load-matrix.outputs.prettier-include }}
       prettier-names: ${{ steps.load-matrix.outputs.prettier-names }}
-      branch: ${{ steps.load-matrix.outputs.branch }}
       release: ${{ steps.load-matrix.outputs.release }}
       reason: ${{ steps.load-matrix.outputs.reason }}
     steps:
@@ -98,9 +95,6 @@ jobs:
           fi
         done
 
-        # Create a properly default property for downstream.
-        echo "::set-output name=branch::${{ github.event.inputs.branch }}"
-
         # If manual trigger sent release.
         if [[ "${{ github.event.inputs.release }}" != "" ]]; then
           echo "::set-output name=release::${{ github.event.inputs.release }}"
@@ -141,11 +135,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ${{ matrix.name }}
-        ref: ${{ needs.meta.outputs.branch }}
+        ref: ${{ github.event.inputs.branch }}
 
     # This is required because the branch setting might be empty (to infer a default), so
     # after checkout we fetch what the checkout action decided to check out.
     - name: Infer branch from checkout
+      id: inferbranch
       run: |
         echo "::set-output name=branch::$(git branch --show-current)"
 
@@ -227,7 +222,7 @@ jobs:
 
         # Where to stage the change.
         push-to-fork: ${{ matrix.fork }}
-        branch: auto-updates/update-deps-${{ needs.meta.outputs.branch }}
+        branch: auto-updates/update-deps-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
 
@@ -237,7 +232,7 @@ jobs:
 
           ${{ steps.updatedeps.outputs.deplog }}
 
-        title: '[${{ needs.meta.outputs.branch }}] Upgrade to latest dependencies'
+        title: '[${{ steps.inferbranch.outputs.branch }}] Upgrade to latest dependencies'
         body: |
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
@@ -266,7 +261,7 @@ jobs:
         SLACK_CHANNEL: ${{ matrix.channel }}
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
-        SLACK_TITLE: "[${{ needs.meta.outputs.branch }}] Updating dependencies for ${{ matrix.name }} failed."
+        SLACK_TITLE: "[${{ steps.inferbranch.outputs.branch }}] Updating dependencies for ${{ matrix.name }} failed."
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -151,7 +151,13 @@ jobs:
     - name: Install Dependencies
       run: |
         cd $(mktemp -d)
-        go get github.com/google/ko/cmd/ko
+        
+        echo '::group:: install ko'
+        curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
+        echo '::endgroup::'
+        
         go get github.com/google/licenseclassifier
         go get github.com/google/go-licenses
         go get knative.dev/test-infra/buoy

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -266,22 +266,6 @@ jobs:
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
-    - name: Notify of pending pull request.
-      uses: rtCamp/action-slack-notify@v2.1.0
-      if: ${{ steps.cpr.outputs.pull-request-url != '' }}
-      env:
-        SLACK_ICON: http://github.com/knative-automation.png?size=48
-        SLACK_USERNAME: knative-automation
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-        SLACK_CHANNEL: ${{ matrix.channel }}
-        SLACK_COLOR: '#228B22'
-        MSG_MINIMAL: 'true'
-        SLACK_TITLE: "Staged update-deps PR for ${{ matrix.name }}."
-        SLACK_MESSAGE: |
-          Please review: ${{ steps.cpr.outputs.pull-request-url }}
-          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
-
   gotool:
     name: Go Format and Imports
     needs: meta
@@ -374,22 +358,6 @@ jobs:
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
-    - name: Notify of pending pull request.
-      uses: rtCamp/action-slack-notify@v2.1.0
-      if: ${{ steps.cpr.outputs.pull-request-url != '' }}
-      env:
-        SLACK_ICON: http://github.com/knative-automation.png?size=48
-        SLACK_USERNAME: knative-automation
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-        SLACK_CHANNEL: ${{ matrix.channel }}
-        SLACK_COLOR: '#228B22'
-        MSG_MINIMAL: 'true'
-        SLACK_TITLE: "Staged gofmt PR for ${{ matrix.name }}."
-        SLACK_MESSAGE: |
-          Please review: ${{ steps.cpr.outputs.pull-request-url }}
-          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
-
   misspell:
     name: Fix Misspellings
     needs: meta
@@ -476,22 +444,6 @@ jobs:
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
-    - name: Notify of pending pull request.
-      uses: rtCamp/action-slack-notify@v2.1.0
-      if: ${{ steps.cpr.outputs.pull-request-url != '' }}
-      env:
-        SLACK_ICON: http://github.com/knative-automation.png?size=48
-        SLACK_USERNAME: knative-automation
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-        SLACK_CHANNEL: ${{ matrix.channel }}
-        SLACK_COLOR: '#228B22'
-        MSG_MINIMAL: 'true'
-        SLACK_TITLE: "Staged misspell PR for ${{ matrix.name }}."
-        SLACK_MESSAGE: |
-          Please review: ${{ steps.cpr.outputs.pull-request-url }}
-          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
-
   update-actions:
     name: Update actions
     needs: meta
@@ -574,22 +526,6 @@ jobs:
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
-    - name: Notify of pending pull request.
-      uses: rtCamp/action-slack-notify@v2.1.0
-      if: ${{ steps.cpr.outputs.pull-request-url != '' }}
-      env:
-        SLACK_ICON: http://github.com/knative-automation.png?size=48
-        SLACK_USERNAME: knative-automation
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-        SLACK_CHANNEL: ${{ matrix.channel }}
-        SLACK_COLOR: '#228B22'
-        MSG_MINIMAL: 'true'
-        SLACK_TITLE: "Staged actions-sync PR for ${{ matrix.name }}."
-        SLACK_MESSAGE: |
-          Please review: ${{ steps.cpr.outputs.pull-request-url }}
-          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
-
   prettier:
     name: Format markdown
     runs-on: ubuntu-latest
@@ -667,20 +603,4 @@ jobs:
         SLACK_TITLE: Format markdown for ${{ matrix.name }} failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          ${{ needs.meta.outputs.reason }} -${{ github.actor }}
-
-    - name: Notify of pending pull request.
-      uses: rtCamp/action-slack-notify@v2.1.0
-      if: ${{ steps.cpr.outputs.pull-request-url != '' }}
-      env:
-        SLACK_ICON: http://github.com/knative-automation.png?size=48
-        SLACK_USERNAME: knative-automation
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-        SLACK_CHANNEL: ${{ matrix.channel }}
-        SLACK_COLOR: '#228B22'
-        MSG_MINIMAL: 'true'
-        SLACK_TITLE: "Staged prettier PR for ${{ matrix.name }}."
-        SLACK_MESSAGE: |
-          Please review: ${{ steps.cpr.outputs.pull-request-url }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -61,8 +61,22 @@ jobs:
         for x in ${{ matrix.files }}; do
           curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done
+
+        # Prior to the cut we have output in the following format:
+        #
+        # - serving.knative.dev/release: "v20210111-9f0302e4"
+        # + serving.knative.dev/release: "v20210112-9f0302e4"
+        #
+        unique_refs=$(git diff | grep serving.knative.dev/release | tr -s ' ' | cut -c43-50 | sort -u | wc -l)
+
+        if [[ "$unique_refs" -ne 1 ]]; then
+          echo "create_pr=true" >> $GITHUB_ENV
+        else
+          printf "\nskipping nightly bump since there are no changes\n"
+        fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
+      if: env.create_pr == 'true'
       with:
         # Who to look like
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -37,19 +37,32 @@ jobs:
         # Map to nightly-specific parameters.
         include:
         - nightly: net-certmanager
+          module: knative.dev/net-certmanager
           directory: ./third_party/cert-manager-latest
           files: net-certmanager.yaml
         - nightly: net-contour
+          module: knative.dev/net-contour
           directory: ./third_party/contour-latest
           files: net-contour.yaml contour.yaml
         - nightly: net-istio
+          module: knative.dev/net-istio
           directory: ./third_party/istio-latest
           files: net-istio.yaml
         - nightly: net-kourier
+          module: knative.dev/net-kourier
           directory: ./third_party/kourier-latest
           files: kourier.yaml
-
     steps:
+    - name: Set up Go 1.15.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+
+    - name: Install Dependencies
+      run: |
+        cd $(mktemp -d)
+        go get github.com/dprotaso/modlog
+
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
       with:
@@ -57,23 +70,45 @@ jobs:
 
     - name: Download nightlies
       shell: bash
+      id: nightlies
       run: |
         for x in ${{ matrix.files }}; do
           curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done
+
+        function release_labels() {
+          git diff | grep 'knative.dev/release' | tr -s ' '
+        }
 
         # Prior to the 'sed' we have output in the following format:
         #
         # - serving.knative.dev/release: "v20210111-9f0302e4"
         # + serving.knative.dev/release: "v20210112-9f0302e4"
         #
-        unique_refs=$(git diff | tr -s ' ' | grep 'knative.dev/release' | sed 's/.* "\(.*\)"$/\1/' | cut -d '-' -f2 | sort -u | wc -l)
+        ref_count=$(release_labels | sed 's/.* "\(.*\)"$/\1/' | cut -d '-' -f2 | sort -u | wc -l)
 
-        if [[ "$unique_refs" -ne 1 ]]; then
-          echo "create_pr=true" >> $GITHUB_ENV
-        else
-          printf "\nskipping nightly bump since there are no changes\n"
+        if [[ "$ref_count" -eq 1 ]]; then
+          echo "::warning file=.github.js,line=1::${{matrix.nightly}} -  skipping bump no changes"
+          exit 0
         fi
+
+        echo "create_pr=true" >> $GITHUB_ENV
+
+        from_sha=$(release_labels | sort -u  | sed 's/^\([+-]\).* ".*-\(.*\)"$/\1 \2/' | grep '-' | cut -d ' ' -f2)
+        to_sha=$(release_labels | sort -u  | sed 's/^\([+-]\).* ".*-\(.*\)"$/\1 \2/' | grep '+' | cut -d ' ' -f2)
+
+        if [[ -z "$from_sha" ]]  || [[ -z "$to_sha" ]]; then
+          echo "::warning file=.github.js,line=1::${{matrix.nightly}} - failed to get valid shas for a diff"
+          exit 0
+        fi
+
+        # capture logs for the module changes
+        deplog=$(modlog -s ${{ matrix.module }} $from_sha $to_sha || true)
+        deplog="${deplog//$'\n'/'%0A'}"
+        deplog="${deplog//$'\r'/'%0D'}"
+        echo "::set-output name=deplog::$deplog"
+
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       if: env.create_pr == 'true'
@@ -90,17 +125,27 @@ jobs:
         delete-branch: true
 
         # Description of the change and PR body.
-        commit-message: 'Update ${{ matrix.nightly }} nightly'
+        commit-message: |
+          Update ${{ matrix.nightly }} nightly
+
+          ${{ steps.nightlies.outputs.deplog }}
+
         title: '[Automated] Update ${{ matrix.nightly }} nightly'
         body: |
+          /assign @knative/networking-wg-leads
+          /cc @knative/networking-wg-leads
+
           Produced via:
           ```shell
           for x in ${{ matrix.files }}; do
             curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
           done
           ```
-          /assign @knative/networking-wg-leads
-          /cc @knative/networking-wg-leads
+
+          Details:
+          ```
+          ${{ steps.nightlies.outputs.deplog }}
+          ```
 
     - name: Post failure notice to Slack
       uses: rtCamp/action-slack-notify@v2.1.0

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -62,12 +62,12 @@ jobs:
           curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done
 
-        # Prior to the cut we have output in the following format:
+        # Prior to the 'sed' we have output in the following format:
         #
         # - serving.knative.dev/release: "v20210111-9f0302e4"
         # + serving.knative.dev/release: "v20210112-9f0302e4"
         #
-        unique_refs=$(git diff | grep serving.knative.dev/release | tr -s ' ' | cut -c43-50 | sort -u | wc -l)
+        unique_refs=$(git diff | tr -s ' ' | grep 'knative.dev/release' | sed 's/.* "\(.*\)"$/\1/' | cut -d '-' -f2 | sort -u | wc -l)
 
         if [[ "$unique_refs" -ne 1 ]]; then
           echo "create_pr=true" >> $GITHUB_ENV

--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -1,5 +1,2 @@
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
-# Tekton doesn't want actions
-- "tektoncd/pipeline"
-- "tektoncd/triggers"

--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -1,2 +1,5 @@
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
+
+# Opted out.
+- "google/go-containerregistry"

--- a/community-exclude.yaml
+++ b/community-exclude.yaml
@@ -1,0 +1,5 @@
+# Outside Knative
+# May be able to cover with "google"
+- "google"
+- "vmware-tanzu"
+- "mattmoor"

--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -1,3 +1,2 @@
 # Don't have ./hack/update-deps.sh --upgrade
 - "google/exposure-notifications-server"
-- "tektoncd/triggers"

--- a/hack/auto-fork.sh
+++ b/hack/auto-fork.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Requires the following:
+# - gh (https://github.com/cli/cli)
+# - buoy (https://github.com/knative/test-infra/tree/master/buoy)
+# - env has GITHUB_TOKEN set.
+# invoke with:
+#   ./hack/auto-fork.sh <org with repos to fork>
+
+org=$1
+if [ -z "$org" ]; then
+  echo "invoke with ./hack/auto-fork.sh <org>, org is required."
+  exit 1
+fi
+
+has () {
+  local seeking=$1; shift
+  local in=1
+  for element; do
+    if [[ $element == "$seeking" ]]; then
+      in=0
+      break
+    fi
+  done
+  return $in
+}
+
+has_fork () {
+  local repository=$1; shift
+  echo "✅ ${repository} is already forked."
+}
+
+make_fork () {
+  local repository=$1; shift
+  echo "🐎 ${repository} will be forked."
+  gh repo fork ${org}/${repo} --remote=false
+  sleep 1
+  if [ $? -eq 0 ]
+  then
+    echo "✅ ${repository} is forked."
+  else
+    echo "❌ ${repository} failed to fork."
+  fi
+}
+
+forked=$(buoy repos knative-automation | sed 's/knative-automation\///')
+
+for i in $(buoy repos ${org}); do
+  repo=$(basename ${i})
+  has $repo ${forked} && has_fork "${org}/${repo}" || make_fork "${org}/${repo}"
+done

--- a/prettier-exclude.yaml
+++ b/prettier-exclude.yaml
@@ -1,7 +1,10 @@
 # Hugo sucks
 - "knative/docs"
-# Declined
+# Declined because of Markdown formatter breaking conventions
 - "knative/client"
+- "knative-sandbox/kn-plugin-admin"
+- "knative-sandbox/kn-plugin-sample"
+- "knative-sandbox/kn-plugin-source-kafka"
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
 # Generated docs have problems

--- a/prettier-exclude.yaml
+++ b/prettier-exclude.yaml
@@ -4,7 +4,5 @@
 - "knative/client"
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
-# Tekton has unresolved issues
-- "tektoncd/pipeline"
 # Generated docs have problems
 - "google/go-containerregistry"

--- a/repos.yaml
+++ b/repos.yaml
@@ -182,12 +182,10 @@
 - name: 'google/go-containerregistry'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/go-containerregistry'
-  channel: 'ggcr'
   assignees: '@jonjohnsonjr @ImJasonH @mattmoor'
 - name: 'google/ko'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/ko'
-  channel: 'ko'
   assignees: '@jonjohnsonjr @ImJasonH @mattmoor'
 
 # vmware-tanzu

--- a/repos.yaml
+++ b/repos.yaml
@@ -176,7 +176,8 @@
 - name: 'google/knative-gcp'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/knative-gcp'
-  channel: 'knative-gcp'
+  # Disabled as too noisy for a low-traffic channel
+  # channel: 'knative-gcp'
   assignees: '@nlopezgi @zhongduo'
 - name: 'google/go-containerregistry'
   meta-organization: 'knative' # Pull actions from the Knative org.

--- a/repos.yaml
+++ b/repos.yaml
@@ -47,6 +47,13 @@
   channel: 'cli'
   assignees: knative/client-wg-leads
 
+# knative-sandbox (reconciler test)
+- name: 'knative-sandbox/reconciler-test'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/reconciler-test'
+  channel: 'test'
+  assignees: knative/eventing-writers knative/serving-writers
+
 # knative-sandbox (samples)
 - name: 'knative-sandbox/sample-controller'
   meta-organization: 'knative-sandbox'

--- a/repos.yaml
+++ b/repos.yaml
@@ -66,6 +66,13 @@
   channel: 'eventing-sources'
   assignees: knative-sandbox/source-wg-leads lberk
 
+# knative-sandbox/control-protocol
+- name: 'knative-sandbox/control-protocol'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/control-protocol'
+  channel: 'eventing-delivery'
+  assignees: knative-sandbox/channel-wg-leads
+
 # knative-sandbox/discovery
 - name: 'knative-sandbox/discovery'
   meta-organization: 'knative-sandbox'

--- a/repos.yaml
+++ b/repos.yaml
@@ -180,14 +180,40 @@
   fork: 'knative-automation/kn-plugin-admin'
   channel: 'cli'
   assignees: 'knative-sandbox/client-writers'
+
+- name: 'knative-sandbox/kn-plugin-diag'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-diag'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+
+- name: 'knative-sandbox/kn-plugin-migration'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-migration'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+
 - name: 'knative-sandbox/kn-plugin-sample'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-sample'
   channel: 'cli'
   assignees: 'knative-sandbox/client-writers'
+
+- name: 'knative-sandbox/kn-plugin-service-log'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-service-log'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+
 - name: 'knative-sandbox/kn-plugin-source-kafka'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-source-kafka'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+
+- name: 'knative-sandbox/kn-plugin-source-kamelet'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-source-kamelet'
   channel: 'cli'
   assignees: 'knative-sandbox/client-writers'
 

--- a/repos.yaml
+++ b/repos.yaml
@@ -167,6 +167,13 @@
   channel: 'net-certmanager'
   assignees: knative-sandbox/networking-wg-leads
 
+# knative-sandbox/kn-plugin-*, sorted alphabetically
+- name: 'knative-sandbox/kn-plugin-sample'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-sample'
+  channel: 'client'
+  assignees: 'knative-sandbox/client-writers'
+
 # google
 - name: 'google/exposure-notifications-server'
   meta-organization: 'knative' # Pull actions from the Knative org.

--- a/repos.yaml
+++ b/repos.yaml
@@ -169,8 +169,8 @@
 - name: 'google/knative-gcp'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/knative-gcp'
-  channel: '@nachocano'
-  assignees: nachocano grantr ian-mi
+  channel: 'knative-gcp'
+  assignees: '@nlopezgi @zhongduo'
 - name: 'google/go-containerregistry'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/go-containerregistry'

--- a/repos.yaml
+++ b/repos.yaml
@@ -168,10 +168,20 @@
   assignees: knative-sandbox/networking-wg-leads
 
 # knative-sandbox/kn-plugin-*, sorted alphabetically
+- name: 'knative-sandbox/kn-plugin-admin'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-admin'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
 - name: 'knative-sandbox/kn-plugin-sample'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-sample'
-  channel: 'client'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+- name: 'knative-sandbox/kn-plugin-source-kafka'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-source-kafka'
+  channel: 'cli'
   assignees: 'knative-sandbox/client-writers'
 
 # google

--- a/repos.yaml
+++ b/repos.yaml
@@ -160,18 +160,6 @@
   channel: 'net-certmanager'
   assignees: knative-sandbox/networking-wg-leads
 
-# tektoncd
-- name: 'tektoncd/pipeline'
-  meta-organization: 'knative' # Pull actions from the Knative org.
-  fork: 'knative-automation/pipeline'
-  channel: '@vdemeester'
-  assignees: tektoncd/core-maintainers
-- name: 'tektoncd/triggers'
-  meta-organization: 'knative' # Pull actions from the Knative org.
-  fork: 'knative-automation/triggers'
-  channel: '@ImJasonH'
-  assignees: tektoncd/core-maintainers
-
 # google
 - name: 'google/exposure-notifications-server'
   meta-organization: 'knative' # Pull actions from the Knative org.


### PR DESCRIPTION
Sync files from knative/community, starting with (generated) OWNERS_ALIASES. Attempt 
to only apply this to knative (and knative-sandbox, if we choose to use 
OWNERS_ALIASES there).

Not sure how to test this...

/hold

Need https://github.com/knative/community/pull/532 submitted first.
